### PR TITLE
Issue #7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ mod_name=Chunk Library
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.1.0a
+mod_version=1.1.0b
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html


### PR DESCRIPTION
Added a check to the TimeHelper class to ensure that the onLevelExit is handled server-side only. Added more logging info for when the MinecraftServer is unable to be found.